### PR TITLE
update ublock filters

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -6542,7 +6542,7 @@ dlfiles.online##+js(nowoif)
 700mbdownload.*##+js(acis, decodeURI, decodeURIComponent)
 moviescounter.*##+js(aopr, LieDetector)
 moviescounter.*##+js(aeld, , _0x)
-hdpopcorns.*##+js(acis, document.createElement, popup)
+hdpopcorns.*##+js(acis, document.createElement, __htas)
 hdpopcorns.*##+js(nowoif)
 hdpopcorns.*##+js(acis, String.fromCharCode, /btoa|break/)
 mkvcinemas.*##+js(aost, Math.random, /\st\.[a-zA-Z]*\s/)
@@ -6552,6 +6552,7 @@ mkvcinemas.*##+js(aost, Math.random, /\st\.[a-zA-Z]*\s/)
 700mbdownload.*##+js(aopr, decodeURI)
 mydownloadtube.*##+js(acis, String.fromCharCode, break)
 mydownloadtube.*##.movie-box > .vert-add
+||vuwomoby.pro^
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4349
 douploads.*##+js(acis, Math, zfgloaded)
@@ -12343,10 +12344,7 @@ extramovies.*##[href^="//vennala.pw/"]
 extramovies.*##center
 extramovies.*##[href="/dlbutton.php"]
 *$script,3p,denyallow=bootstrapcdn.com|disqus.com|jsdelivr.net|jwpcdn.com|fastly.net|fastlylb.net|jquery.com|hwcdn.net|recaptcha.net|cloudflare.com|cloudflare.net|google.com|googleapis.com|gstatic.com|facebook.net,domain=extramovies.*
-
-! https://github.com/NanoAdblocker/NanoFilters/issues/268
-naisho.website##+js(acis, Math, zfgloaded)
-naisho.website##+js(acis, String.fromCharCode, /btoa|break/)
+extramovies.*###theme_back
 
 ! https://github.com/uBlockOrigin/uAssets/issues/4835
 @@||googletagmanager.com/gtm.js$script,domain=ciudad.com.ar
@@ -15531,6 +15529,7 @@ watchseries.*##+js(acis, Math, XMLHttpRequest)
 watchseries.*##+js(nosiif, visibility, 1000)
 watchseries.*##+js(aeld, , popMagic)
 ||watchseries.*/sw.js$script,1p
+watchseriess.co##+js(acis, Math, break;case $.)
 
 ! https://github.com/NanoMeow/QuickReports/issues/1322
 @@||loskatchorros.com.br^$ghide
@@ -20069,11 +20068,6 @@ alliptvlinks.com##+js(aeld, load, ads)
 alliptvlinks.com###arlinablock
 alliptvlinks.com##body:style(overflow: auto !important)
 
-! https://github.com/NanoMeow/QuickReports/issues/2603
-coswitmedia.com##+js(acis, Math, zfgloaded)
-coswitmedia.com##+js(nowebrtc)
-coswitmedia.com##.greatwp-featured-posts-area
-
 ! https://github.com/uBlockOrigin/uAssets/issues/6765
 uptobox.com,uptostream.com##+js(set, jsUnda, noopFunc)
 
@@ -20163,11 +20157,6 @@ shortbitsfree.net##+js(aopr, app_vars.force_disable_adblock)
 shortbitsfree.net##+js(aopr, open)
 shortbitsfree.net##.banner
 ||neobits.net^$3p
-
-! https://github.com/uBlockOrigin/uAssets/issues/6780
-1tamilmv.*##+js(acis, Math, zfgloaded)
-1tamilmv.*##+js(aopw, _pop)
-1tamilmv.*##+js(aeld, , _0x)
 ||mugaskems.com^
 
 ! https://github.com/uBlockOrigin/uAssets/issues/6781
@@ -20663,9 +20652,6 @@ p4link.com##.blog-item
 ! https://github.com/uBlockOrigin/uAssets/issues/6895
 daily-times.com##+js(aopr, _sp_._networkListenerData)
 
-! popups moviewatcher. is
-moviewatcher.*##+js(acis, Math, zfgloaded)
-
 ! https://github.com/NanoMeow/QuickReports/issues/2868
 @@||googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=lexigram.gr
 
@@ -20689,14 +20675,12 @@ techtobo.com##+js(aopr, adBlockDetected)
 ! https://github.com/NanoMeow/QuickReports/issues/2873
 onmovie.online##+js(acis, puShown , /doOpen|popundr/)
 
-! https://github.com/NanoMeow/QuickReports/issues/2876
-@@||ld2tv.net^$ghide
-ld2tv.net##+js(acis, Math, zfgloaded)
-ld2tv.net##+js(aopr, glxopen)
-21stream.online##+js(aopr, open)
+! langitfilm.vip ads & antiadblock
+langitfilm.vip##+js(nosiif, visibility, 1000)
+langitfilm.vip##+js(acis, Math, break;case $.)
 ||assandart.site^
 ||curarmbin.club^
-*.gif$domain=ld2tv.net,image
+||aimseerg.com^
 
 ! https://github.com/NanoMeow/QuickReports/issues/2877
 @@||hausbau-forum.de/js/siropu/am/ads.min.js$script,1p


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

```
hdpopcorns.eu
extramovies.team
watchseriess.co
langitfilm.vip
```
### Describe the issue

Ads at `hdpopcorns.eu`
`naisho.website` dead
`watchseries.fm` redirect to `watchseriess.co` and ads
`cosmitmedia.com` unreachable
`1tamilmv.com` to `1tamilmv.nl` ,no crap/ads as of now on `1tamilmv.nl `that require scriptlets
`moviewatcher.is` scriptlet obsolete
`ld2tv.net` redirect to `langitfilm.vip` ,there is antiadblock here
`21stream.online` is dead

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: opera stable
- uBlock Origin version: 1.34.1b2

### Settings

-  uBO's default settings

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
