### PR TITLE
address extratorrents.it popups

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -2601,3 +2601,6 @@ therootdroid.com##+js(aopw, ai_front)
 
 ! pogolinks. website popups
 pogolinks.*##+js(aost, Math.floor, )
+
+! extratorrents. it popups
+extratorrents.*##+js(aopw, adcashMacros)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://extratorrents.it/torrent/8648228/Pagglait+%282021%29+%5BHINDI%2BENGLISH+-+720p+-+WEB+HDRip+-+x264+-+DD+5.1+-+MSub+-+2GB%5D+-+MAZE.html`

### Describe the issue

popup ads

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox a
- uBlock Origin version: 1.34

### Settings

-  uBO's default settings

### Notes

