### PR TITLE
update speedostream

### DIFF
--- a/filters/filters-2021.txt
+++ b/filters/filters-2021.txt
@@ -1476,7 +1476,6 @@ speedostream.com##+js(acis, Math, break;case $.)
 speedostream.com##+js(aost, Object.getOwnPropertyDescriptor, /^/)
 speedostream.com##+js(aost, JSON.parse, computed)
 speedostream.com##^script:has-text(break;case $.)
-speedostream.com##+js(nowoif)
 
 ! https://github.com/AdguardTeam/AdguardFilters/issues/76775
 @@||assistir.one^$ghide


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs

`https://speedostream.com/embed-q126z1mw1pph.html`

access via `https://prmovies.mx/loki-2021-season-1-hindi-dubbed-hotstar-specials-Watch-online-on-prmovies/` 
server 1


### Describe the issue

`speedostream.com##+js(nowoif)` breaks download that is there in embed player 

### Screenshot(s)
![IMG_20210610_151856](https://user-images.githubusercontent.com/20338483/121504280-84653200-c9ff-11eb-96cf-4492696927f1.jpg)



### Versions

- Browser/version: firefox a nightly
- uBlock Origin version: 1.35.2

### Settings

- uBO's default settings

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
