### PR TITLE
update

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -19114,12 +19114,6 @@ warps.club##+js(aopr, adblockDetect)
 ! https://github.com/NanoMeow/QuickReports/issues/2890
 *$script,redirect-rule=noopjs,domain=texviewer.herokuapp.com
 
-! https://github.com/NanoMeow/QuickReports/issues/2891
-megasubtitles.com##+js(aopw, _pop)
-megasubtitles.com##^meta[http-equiv="refresh"]
-megasubtitles.com###popback
-megasubtitles.com###pop1
-
 ! https://github.com/NanoMeow/QuickReports/issues/2894
 heidisql.com##+js(acis, $, adblock)
 


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->

### URL(s) where the issue occurs
`megasubtitles.com`

### Describe the issue

site is blank with ubo enabled
refresh to new site `subtitles123.com` is prevented

### Screenshot(s)

[Screenshot(s) for difficult to describe visual issues are **mandatory**]

### Versions

- Browser/version: firefox
- uBlock Origin version: 1.37.2

### Settings

- uBO's default settings

### Notes

[Add here the result of whatever investigation work you have done: please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones.]
